### PR TITLE
[Refactor] NetworkManager 홈 파트 분리 작업

### DIFF
--- a/SoBunSoBun/Common/NetworkManager/AuthorizedAPI.swift
+++ b/SoBunSoBun/Common/NetworkManager/AuthorizedAPI.swift
@@ -13,15 +13,7 @@ enum AuthorizedAPI {
     // 로그인
     case saveProfile(nickname: String, profileImage: Data?)
     case me
-    // 홈
-    case getLocationVerification
-    case patchLocationVerification(address: String)
-    case getHomeList(page: Int, size: Int)
-    case getHomeListByCategories(category: [String], page: Int, size: Int)
-    case registerPost(model: RegisterPostBodyModel)
-    // 검색
-    case getSuggestions
-    case getSearchList(keyword: String, sortBy: String, page: Int, size: Int)
+    
     // 정산
     case mySettleUps(activeOnly: Int, page: Int, size: Int)
     case deleteSettleUp(id: Int)
@@ -47,20 +39,6 @@ extension AuthorizedAPI: TargetType {
             return "/users/me/profile"
         case .me:
             return "/api/me"
-        case .getLocationVerification:
-            return "/api/me/location-verification"
-        case .patchLocationVerification:
-            return "/api/me/location-verification"
-        case .getHomeList:
-            return "/api/posts"
-        case .getHomeListByCategories(let category, page: _, size: _):
-            return "/api/posts/categories/\(category.joined(separator: ","))"
-        case .registerPost:
-            return "/api/posts"
-        case .getSuggestions:
-            return "/api/search/suggestions/default"
-        case .getSearchList:
-            return "/api/search"
         case .mySettleUps:
             return "/api/settleups/my"
         case .deleteSettleUp(let id):
@@ -79,20 +57,6 @@ extension AuthorizedAPI: TargetType {
         case .saveProfile:
             return .patch
         case .me:
-            return .get
-        case .getLocationVerification:
-            return .get
-        case .patchLocationVerification:
-            return .patch
-        case .getHomeList:
-            return .get
-        case .getHomeListByCategories:
-            return .get
-        case .registerPost:
-            return .post
-        case .getSuggestions:
-            return .get
-        case .getSearchList:
             return .get
         case .mySettleUps:
             return .get
@@ -137,35 +101,6 @@ extension AuthorizedAPI: TargetType {
             
         case .me:
             return .requestPlain
-            
-        case .getLocationVerification:
-            return .requestPlain
-            
-        case .patchLocationVerification(let address):
-            let body = LocationVerificationBodyModel(address: address)
-            
-            return .requestJSONEncodable(body)
-            
-        case .getHomeList(let page, let size):
-            let parameters = HomeListRequestModel(page: page, size: size)
-            
-            return .requestParameters(parameters: parameters.toDictionary()!, encoding: URLEncoding.queryString)
-            
-        case .getHomeListByCategories(category: _, let page, let size):
-            let parameters = HomeListRequestModel(page: page, size: size)
-            
-            return .requestParameters(parameters: parameters.toDictionary()!, encoding: URLEncoding.queryString)
-            
-        case .registerPost(let model):
-            return .requestJSONEncodable(model)
-            
-        case .getSuggestions:
-            return .requestPlain
-            
-        case .getSearchList(let keyword, let sortBy, let page, let size):
-            let parameters = SearchListRequestModel(keyword: keyword, sortBy: sortBy, page: page, size: size)
-            
-            return .requestParameters(parameters: parameters.toDictionary()!, encoding: URLEncoding.queryString)
         
         case .mySettleUps(let activeOnly, let page, let size):
             let parameters = SettleUpMyRequestModel(activeOnly: activeOnly, page: page, size: size)
@@ -204,13 +139,6 @@ extension AuthorizedAPI: TargetType {
             .patchProfileImage:
             return ["Content-Type": "multipart/form-data"]
         case .me,
-                .getLocationVerification,
-                .patchLocationVerification,
-                .getHomeList,
-                .getHomeListByCategories,
-                .registerPost,
-                .getSuggestions,
-                .getSearchList,
                 .mySettleUps,
                 .deleteSettleUp,
                 .getMeProfile,

--- a/SoBunSoBun/Common/NetworkManager/AuthorizedModel.swift
+++ b/SoBunSoBun/Common/NetworkManager/AuthorizedModel.swift
@@ -60,42 +60,6 @@ struct RefreshResponseModel: Decodable {
     let expiresIn: Int
 }
 
-// MARK: - 홈
-struct LocationVerificationModel: Decodable {
-    let address, locationVerifiedAt: String?
-    let remainingMinutes: Int?
-    let verified, expired: Bool
-}
-
-struct LocationVerificationBodyModel: Encodable {
-    let address: String
-}
-
-struct HomeListRequestModel: Encodable {
-    let page, size: Int
-}
-
-struct HomeListCategoryRequestModel: Encodable {
-    let categories: [String]
-    let page, size: Int
-}
-
-struct RegisterPostBodyModel: Encodable {
-    let title, categories, locationName, meetAt, deadlineAt, itemsText, notesText: String
-    let minMembers, maxMembers: Int
-}
-
-// MARK: - 검색
-struct SuggestionSearchKeywordsModel: Decodable {
-    let suggestions: [String]
-    let count: Int
-}
-
-struct SearchListRequestModel: Encodable {
-    let keyword, sortBy: String
-    let page, size: Int
-}
-
 // MARK: - 정산
 struct SettleUpModel: Decodable {
     let content: [SettleUpContentModel]

--- a/SoBunSoBun/Common/NetworkManager/NetworkManager.swift
+++ b/SoBunSoBun/Common/NetworkManager/NetworkManager.swift
@@ -14,6 +14,7 @@ import OSLog
 
 // TODO: 파일 분할 필요
 final class NetworkManager {
+    // 분리 작업 이후 더 이상 싱글톤 패턴으로 유지할 이유가 없어 보일 것 같습니다.
     static let shared = NetworkManager()
     
     private init() {}
@@ -69,81 +70,6 @@ final class NetworkManager {
         )
         .filterSuccessfulStatusCodes()
         .map(UserInfoModel.self)
-    }
-    
-    // MARK: - 홈
-    // 현재 사용자 위치 인증 상태 조회
-    func getLocationVefirication() -> Single<LocationVerificationModel> {
-        return authProvider.rx.request(
-            MultiTarget(AuthorizedAPI.getLocationVerification)
-        )
-        .filterSuccessfulStatusCodes()
-        .map(LocationVerificationModel.self)
-    }
-    
-    // 좌표를 통해 주소 변환
-    func getAddresFromGeocoder(longitude: Double, latitude: Double) -> Single<GeocoderResponseModel> {
-        let point: String = "\(longitude),\(latitude)"
-        
-        return provider.rx.request(
-            MultiTarget(PublicAPI.getAddress(point: point))
-        )
-        .filterSuccessfulStatusCodes()
-        .map(GeocoderResponseModel.self)
-    }
-    
-    // 사용자 위치 인증
-    func patchLocationVerification(address: String) -> Single<LocationVerificationModel> {
-        return authProvider.rx.request(
-            MultiTarget(AuthorizedAPI.patchLocationVerification(address: address))
-        )
-        .filterSuccessfulStatusCodes()
-        .map(LocationVerificationModel.self)
-    }
-    
-    // 홈 게시글 목록 불러오기
-    func getHomeList(page: Int, size: Int) -> Single<PostListResponseModel> {
-        return authProvider.rx.request(
-            MultiTarget(AuthorizedAPI.getHomeList(page: page, size: size))
-        )
-        .filterSuccessfulStatusCodes()
-        .map(PostListResponseModel.self)
-    }
-    
-    // 카테고리 선택 후 홈 게시글 목록 불러오기
-    func getHomeListByCategories(categories: [String], page: Int, size: Int) -> Single<PostListResponseModel> {
-        return authProvider.rx.request(
-            MultiTarget(AuthorizedAPI.getHomeListByCategories(category: categories, page: page, size: size))
-        )
-        .filterSuccessfulStatusCodes()
-        .map(PostListResponseModel.self)
-    }
-    
-    // 글 등록
-    func registerPost(model: RegisterPostBodyModel) -> Single<PostModel> {
-        return authProvider.rx.request(
-            MultiTarget(AuthorizedAPI.registerPost(model: model))
-        )
-        .filterSuccessfulStatusCodes()
-        .map(PostModel.self)
-    }
-    
-    // MARK: - 검색
-    // 추천 검색어
-    func getSuggestions() -> Single<SuggestionSearchKeywordsModel> {
-        return authProvider.rx.request(
-            MultiTarget(AuthorizedAPI.getSuggestions)
-        )
-        .filterSuccessfulStatusCodes()
-        .map(SuggestionSearchKeywordsModel.self)
-    }
-    
-    func getSearchList(keyword: String, sortBy: String, page: Int, size: Int) -> Single<PostListResponseModel> {
-        return authProvider.rx.request(
-            MultiTarget(AuthorizedAPI.getSearchList(keyword: keyword, sortBy: sortBy, page: page, size: size))
-        )
-        .filterSuccessfulStatusCodes()
-        .map(PostListResponseModel.self)
     }
     
     // MARK: - 정산

--- a/SoBunSoBun/Common/NetworkManager/PublicAPI.swift
+++ b/SoBunSoBun/Common/NetworkManager/PublicAPI.swift
@@ -16,8 +16,6 @@ enum PublicAPI {
     case authCompleteSignUp(loginToken: String, serviceTermsAgreed: Bool, privacyPolicyAgreed: Bool, marketingOptionalAgreed: Bool)
     case health
     case checkNickname(nickname: String) // 닉네임 중복 검사 API
-    // 홈
-    case getAddress(point: String) // 좌표를 통해 주소 가져오기
 }
 
 extension PublicAPI: TargetType {
@@ -25,8 +23,6 @@ extension PublicAPI: TargetType {
         switch self {
         case .authLoginKakao, .authCompleteSignUp, .health, .checkNickname:
             return URL(string: API_URL)!
-        case .getAddress:
-            return URL(string: "https://api.vworld.kr")!
         }
     }
     
@@ -40,8 +36,6 @@ extension PublicAPI: TargetType {
             return "/health"
         case .checkNickname:
             return "/users/check-nickname"
-        case .getAddress:
-            return "/req/address"
         }
     }
     
@@ -54,8 +48,6 @@ extension PublicAPI: TargetType {
         case .health:
             return .get
         case .checkNickname:
-            return .get
-        case .getAddress:
             return .get
         }
     }
@@ -78,11 +70,6 @@ extension PublicAPI: TargetType {
             return .requestPlain
         case .checkNickname(nickname: let nickname):
             return .requestParameters(parameters: ["nickname": nickname], encoding: URLEncoding.queryString)
-        case .getAddress(point: let point):
-            let key = Bundle.main.object(forInfoDictionaryKey: "VWORLD_CERT_KEY") as! String
-            let model = GeocoderRequestModel(point: point, key: key)
-            
-            return .requestParameters(parameters: model.toDictionary()!, encoding: URLEncoding(destination: .queryString, arrayEncoding: .brackets, boolEncoding: .literal))
         }
     }
     

--- a/SoBunSoBun/Common/NetworkManager/PublicModel.swift
+++ b/SoBunSoBun/Common/NetworkManager/PublicModel.swift
@@ -38,35 +38,3 @@ struct CheckNicknameModel: Decodable {
     let nickname: String
     let available: Bool
 }
-
-// MARK: - 홈
-struct GeocoderRequestModel: Encodable {
-    let service: String = "address"
-    let request: String = "getAddress"
-    let version: String = "2.0"
-    let crs: String = "epsg:4326"
-    let format: String = "json"
-    let errorformat: String = "json"
-    let type: String = "parcel"
-    let zipcode: Bool = false
-    let simple: Bool = true
-    let point: String
-    let key: String
-}
-
-struct GeocoderResponseModel: Decodable {
-    let response: GeocoderResponseInsideModel
-}
-
-struct GeocoderResponseInsideModel: Decodable {
-    let result: [GeocoderResponseResultModel]
-}
-
-struct GeocoderResponseResultModel: Decodable {
-    let text: String
-    let structure: GeocoderResponseResultStructureModel
-}
-
-struct GeocoderResponseResultStructureModel: Decodable {
-    let level1, level2, level3: String
-}

--- a/SoBunSoBun/Views/Home/Home/HomeReactor.swift
+++ b/SoBunSoBun/Views/Home/Home/HomeReactor.swift
@@ -17,6 +17,7 @@ class HomeReactor: Reactor {
     )
     
     private let disposeBag = DisposeBag()
+    private let networkManager = HomeNetworkManager()
     
     let initialState: State = State()
     private let pageSize: Int = 20
@@ -185,7 +186,7 @@ class HomeReactor: Reactor {
     
     // 서버로부터 위치 인증 정보 불러오기
     private func verifyLocation() -> Observable<Mutation> {
-        return NetworkManager.shared.getLocationVefirication()
+        return networkManager.getLocationVefirication()
             .asObservable()
             .flatMap { model -> Observable<Mutation> in
                 if let address = model.address, !model.expired {
@@ -271,7 +272,7 @@ class HomeReactor: Reactor {
     
     // 지오코더 API 호출
     private func getAddressFromGeocoder(longitude: Double, latitude: Double) -> Observable<Mutation> {
-        return NetworkManager.shared.getAddresFromGeocoder(longitude: longitude, latitude: latitude)
+        return networkManager.getAddresFromGeocoder(longitude: longitude, latitude: latitude)
             .asObservable()
             .flatMap { model -> Observable<Mutation> in
                 let structure = model.response.result[0].structure
@@ -291,7 +292,7 @@ class HomeReactor: Reactor {
     
     // 서버에 위치 인증 갱신
     private func patchLocationVerification(address: String) -> Observable<Mutation> {
-        return NetworkManager.shared.patchLocationVerification(address: address)
+        return networkManager.patchLocationVerification(address: address)
             .asObservable()
             .map { model -> Mutation in
                 if let address = model.address {
@@ -313,8 +314,8 @@ class HomeReactor: Reactor {
     private func loadPosts(page: Int, isFirst: Bool, categories: [String] = []) -> Observable<Mutation> {
         // API 호출
         let api: Single<PostListResponseModel> = categories.isEmpty
-        ? NetworkManager.shared.getHomeList(page: page, size: pageSize)
-        : NetworkManager.shared.getHomeListByCategories(categories: categories, page: page, size: pageSize)
+        ? networkManager.getHomeList(page: page, size: pageSize)
+        : networkManager.getHomeListByCategories(categories: categories, page: page, size: pageSize)
         
         return Observable.concat([
             Observable.just(.setLoading(true)),

--- a/SoBunSoBun/Views/Home/RegisterPost/RegisterPostReactor.swift
+++ b/SoBunSoBun/Views/Home/RegisterPost/RegisterPostReactor.swift
@@ -17,6 +17,7 @@ class RegisterPostReactor: Reactor {
     )
     
     private let disposeBag = DisposeBag()
+    private let networkManager = HomeNetworkManager()
     
     let initialState: State = State()
     
@@ -233,7 +234,7 @@ class RegisterPostReactor: Reactor {
         
         return Observable.concat([
             Observable.just(.setLoading(true)),
-            NetworkManager.shared.registerPost(model: model)
+            networkManager.registerPost(model: model)
                 .asObservable()
                 .flatMap { model -> Observable<Mutation> in
                     self.logger.debug("\(title) 게시글 등록 성공")

--- a/SoBunSoBun/Views/Home/Search/SearchReactor.swift
+++ b/SoBunSoBun/Views/Home/Search/SearchReactor.swift
@@ -17,6 +17,7 @@ class SearchReactor: Reactor {
     )
     
     private let disposeBag = DisposeBag()
+    private let networkManager = HomeNetworkManager()
     
     let initialState: State = State()
     private let pageSize: Int = 20
@@ -231,7 +232,7 @@ class SearchReactor: Reactor {
         let sortBy = sortBy.replacingOccurrences(of: "SortBy", with: "").lowercased()
         
         // API 호출
-        let api: Single<PostListResponseModel> = NetworkManager.shared.getSearchList(keyword: keyword, sortBy: sortBy, page: page, size: pageSize)
+        let api: Single<PostListResponseModel> = networkManager.getSearchList(keyword: keyword, sortBy: sortBy, page: page, size: pageSize)
         
         return Observable.concat([
             Observable.just(.setLoading(true)),

--- a/SoBunSoBun/Views/Home/_NetworkManager/HomeAPIModels.swift
+++ b/SoBunSoBun/Views/Home/_NetworkManager/HomeAPIModels.swift
@@ -8,8 +8,71 @@
 import Foundation
 
 // MARK: - 피드
+struct LocationVerificationModel: Decodable {
+    let address, locationVerifiedAt: String?
+    let remainingMinutes: Int?
+    let verified, expired: Bool
+}
+
+struct LocationVerificationBodyModel: Encodable {
+    let address: String
+}
+
+struct HomeListRequestModel: Encodable {
+    let page, size: Int
+}
+
+struct HomeListCategoryRequestModel: Encodable {
+    let categories: [String]
+    let page, size: Int
+}
+
+struct RegisterPostBodyModel: Encodable {
+    let title, categories, locationName, meetAt, deadlineAt, itemsText, notesText: String
+    let minMembers, maxMembers: Int
+}
+
+struct GeocoderRequestModel: Encodable {
+    let service: String = "address"
+    let request: String = "getAddress"
+    let version: String = "2.0"
+    let crs: String = "epsg:4326"
+    let format: String = "json"
+    let errorformat: String = "json"
+    let type: String = "parcel"
+    let zipcode: Bool = false
+    let simple: Bool = true
+    let point: String
+    let key: String
+}
+
+struct GeocoderResponseModel: Decodable {
+    let response: GeocoderResponseInsideModel
+}
+
+struct GeocoderResponseInsideModel: Decodable {
+    let result: [GeocoderResponseResultModel]
+}
+
+struct GeocoderResponseResultModel: Decodable {
+    let text: String
+    let structure: GeocoderResponseResultStructureModel
+}
+
+struct GeocoderResponseResultStructureModel: Decodable {
+    let level1, level2, level3: String
+}
 
 // MARK: - 검색
+struct SuggestionSearchKeywordsModel: Decodable {
+    let suggestions: [String]
+    let count: Int
+}
+
+struct SearchListRequestModel: Encodable {
+    let keyword, sortBy: String
+    let page, size: Int
+}
 
 // MARK: - 게시글 상세
 struct CommentCountModel: Decodable, Equatable {

--- a/SoBunSoBun/Views/Home/_NetworkManager/HomeAPIs.swift
+++ b/SoBunSoBun/Views/Home/_NetworkManager/HomeAPIs.swift
@@ -10,8 +10,16 @@ import Moya
 
 enum HomeAPIs {
     // 피드
+    case getLocationVerification
+    case patchLocationVerification(address: String)
+    case getHomeList(page: Int, size: Int)
+    case getHomeListByCategories(category: [String], page: Int, size: Int)
+    case getAddress(point: String) // 좌표를 통해 주소 가져오기
+    case registerPost(model: RegisterPostBodyModel)
     
     // 검색
+    case getSuggestions
+    case getSearchList(keyword: String, sortBy: String, page: Int, size: Int)
     
     // 게시글 상세
     case getPost(id: Int)
@@ -35,15 +43,45 @@ extension HomeAPIs: TargetType {
     }
     
     var baseURL: URL {
-        return URL(string: API_URL)!
+        switch self {
+        case .getAddress:
+            return URL(string: "https://api.vworld.kr")!
+            
+        default:
+            return URL(string: API_URL)!
+        }
     }
     
     var path: String {
         switch self {
+        case .getLocationVerification:
+            return "/api/me/location-verification"
+            
+        case .patchLocationVerification:
+            return "/api/me/location-verification"
+            
+        case .getHomeList:
+            return "/api/posts"
+            
+        case .getHomeListByCategories(let category, page: _, size: _):
+            return "/api/posts/categories/\(category.joined(separator: ","))"
+            
+        case .getAddress:
+            return "/req/address"
+            
+        case .registerPost:
+            return "/api/posts"
+            
+        case .getSuggestions:
+            return "/api/search/suggestions/default"
+            
+        case .getSearchList:
+            return "/api/search"
+            
         case .getPost(let id), .deletePost(let id):
             return "/api/posts/\(id)"
             
-        case .checkPostSaved(let id):
+        case .checkPostSaved:
             return "/api/v1/posts/saved/check"
             
         case .getPostCommentsCount(let id):
@@ -72,6 +110,12 @@ extension HomeAPIs: TargetType {
     var method: Moya.Method {
         switch self {
         case // GET
+                .getLocationVerification,
+                .getHomeList,
+                .getHomeListByCategories,
+                .getAddress,
+                .getSuggestions,
+                .getSearchList,
                 .getPost,
                 .checkPostSaved,
                 .getPostCommentsCount,
@@ -79,6 +123,7 @@ extension HomeAPIs: TargetType {
             return .get
             
         case // POST
+                .registerPost,
                 .savePost,
                 .reportPost,
                 .createPostComment,
@@ -86,6 +131,7 @@ extension HomeAPIs: TargetType {
             return .post
             
         case // PATCH
+                .patchLocationVerification,
                 .patchPostComment:
             return .patch
             
@@ -99,6 +145,41 @@ extension HomeAPIs: TargetType {
     
     var task: Moya.Task {
         switch self {
+        case .getLocationVerification:
+            return .requestPlain
+            
+        case .patchLocationVerification(let address):
+            let body = LocationVerificationBodyModel(address: address)
+            
+            return .requestJSONEncodable(body)
+            
+        case .getHomeList(let page, let size):
+            let parameters = HomeListRequestModel(page: page, size: size)
+            
+            return .requestParameters(parameters: parameters.toDictionary()!, encoding: URLEncoding.queryString)
+            
+        case .getHomeListByCategories(category: _, let page, let size):
+            let parameters = HomeListRequestModel(page: page, size: size)
+            
+            return .requestParameters(parameters: parameters.toDictionary()!, encoding: URLEncoding.queryString)
+            
+        case .getAddress(point: let point):
+            let key = Bundle.main.object(forInfoDictionaryKey: "VWORLD_CERT_KEY") as! String
+            let model = GeocoderRequestModel(point: point, key: key)
+            
+            return .requestParameters(parameters: model.toDictionary()!, encoding: URLEncoding(destination: .queryString, arrayEncoding: .brackets, boolEncoding: .literal))
+            
+        case .registerPost(let model):
+            return .requestJSONEncodable(model)
+            
+        case .getSuggestions:
+            return .requestPlain
+            
+        case .getSearchList(let keyword, let sortBy, let page, let size):
+            let parameters = SearchListRequestModel(keyword: keyword, sortBy: sortBy, page: page, size: size)
+            
+            return .requestParameters(parameters: parameters.toDictionary()!, encoding: URLEncoding.queryString)
+            
         case .getPost:
             return .requestPlain
             
@@ -147,21 +228,6 @@ extension HomeAPIs: TargetType {
     }
     
     var headers: [String : String]? {
-        switch self {
-        case // None
-                .getPost,
-                .checkPostSaved,
-                .getPostCommentsCount,
-                .getPostComments,
-                .savePost,
-                .cancelSavePost,
-                .reportPost,
-                .deletePost,
-                .createPostComment,
-                .patchPostComment,
-                .deletePostComment,
-                .reportPostComment:
-            return [:]
-        }
+        return [:]
     }
 }

--- a/SoBunSoBun/Views/Home/_NetworkManager/HomeNetworkManager.swift
+++ b/SoBunSoBun/Views/Home/_NetworkManager/HomeNetworkManager.swift
@@ -11,16 +11,91 @@ import RxMoya
 import RxSwift
 
 class HomeNetworkManager {
-    private let provider = MoyaProvider<MultiTarget>(session: Session(interceptor: AuthInterceptor.shared), plugins: [MoyaLoggingPlugin()])
+    private let provider = MoyaProvider<MultiTarget>(plugins: [MoyaLoggingPlugin()])
+    private let authProvider = MoyaProvider<MultiTarget>(session: Session(interceptor: AuthInterceptor.shared), plugins: [MoyaLoggingPlugin()])
     
     // MARK: - 피드
+    // 현재 사용자 위치 인증 상태 조회
+    func getLocationVefirication() -> Single<LocationVerificationModel> {
+        return authProvider.rx.request(
+            MultiTarget(HomeAPIs.getLocationVerification)
+        )
+        .filterSuccessfulStatusCodes()
+        .map(LocationVerificationModel.self)
+    }
+    
+    // 좌표를 통해 주소 변환
+    func getAddresFromGeocoder(longitude: Double, latitude: Double) -> Single<GeocoderResponseModel> {
+        let point: String = "\(longitude),\(latitude)"
+        
+        return provider.rx.request(
+            MultiTarget(HomeAPIs.getAddress(point: point))
+        )
+        .filterSuccessfulStatusCodes()
+        .map(GeocoderResponseModel.self)
+    }
+    
+    // 사용자 위치 인증
+    func patchLocationVerification(address: String) -> Single<LocationVerificationModel> {
+        return authProvider.rx.request(
+            MultiTarget(HomeAPIs.patchLocationVerification(address: address))
+        )
+        .filterSuccessfulStatusCodes()
+        .map(LocationVerificationModel.self)
+    }
+    
+    // 홈 게시글 목록 불러오기
+    func getHomeList(page: Int, size: Int) -> Single<PostListResponseModel> {
+        return authProvider.rx.request(
+            MultiTarget(HomeAPIs.getHomeList(page: page, size: size))
+        )
+        .filterSuccessfulStatusCodes()
+        .map(PostListResponseModel.self)
+    }
+    
+    // 카테고리 선택 후 홈 게시글 목록 불러오기
+    func getHomeListByCategories(categories: [String], page: Int, size: Int) -> Single<PostListResponseModel> {
+        return authProvider.rx.request(
+            MultiTarget(HomeAPIs.getHomeListByCategories(category: categories, page: page, size: size))
+        )
+        .filterSuccessfulStatusCodes()
+        .map(PostListResponseModel.self)
+    }
+    
+    // 글 등록
+    func registerPost(model: RegisterPostBodyModel) -> Single<PostModel> {
+        return authProvider.rx.request(
+            MultiTarget(HomeAPIs.registerPost(model: model))
+        )
+        .filterSuccessfulStatusCodes()
+        .map(PostModel.self)
+    }
     
     // MARK: - 검색
+    // 추천 검색어
+    /*
+    func getSuggestions() -> Single<SuggestionSearchKeywordsModel> {
+        return authProvider.rx.request(
+            MultiTarget(AuthorizedAPI.getSuggestions)
+        )
+        .filterSuccessfulStatusCodes()
+        .map(SuggestionSearchKeywordsModel.self)
+    }
+    */
+    
+    // 검색 결과 불러오기
+    func getSearchList(keyword: String, sortBy: String, page: Int, size: Int) -> Single<PostListResponseModel> {
+        return authProvider.rx.request(
+            MultiTarget(HomeAPIs.getSearchList(keyword: keyword, sortBy: sortBy, page: page, size: size))
+        )
+        .filterSuccessfulStatusCodes()
+        .map(PostListResponseModel.self)
+    }
     
     // MARK: - 게시글 상세
     // 게시글 상세 정보 불러오기
     func getPost(id: Int) -> Single<PostModel> {
-        return provider.rx.request(
+        return authProvider.rx.request(
             MultiTarget(HomeAPIs.getPost(id: id))
         )
         .filterSuccessfulStatusCodes()
@@ -29,7 +104,7 @@ class HomeNetworkManager {
     
     // 게시글 저장 유무 불러오기
     func checkPostSaved(id: Int) -> Single<Bool> {
-        return provider.rx.request(
+        return authProvider.rx.request(
             MultiTarget(HomeAPIs.checkPostSaved(id: id))
         )
         .filterSuccessfulStatusCodes()
@@ -38,7 +113,7 @@ class HomeNetworkManager {
     
     // 게시글 댓글 개수 불러오기
     func getPostCommentsCount(id: Int) -> Single<CommentCountModel> {
-        return provider.rx.request(
+        return authProvider.rx.request(
             MultiTarget(HomeAPIs.getPostCommentsCount(id: id))
         )
         .filterSuccessfulStatusCodes()
@@ -47,7 +122,7 @@ class HomeNetworkManager {
     
     // 게시글 댓글 불러오기
     func getPostComments(id: Int) -> Single<[CommentModel]> {
-        return provider.rx.request(
+        return authProvider.rx.request(
             MultiTarget(HomeAPIs.getPostComments(id: id))
         )
         .filterSuccessfulStatusCodes()
@@ -56,7 +131,7 @@ class HomeNetworkManager {
     
     // 게시글 저장
     func savePost(id: Int) -> Single<Void> {
-        return provider.rx.request(
+        return authProvider.rx.request(
             MultiTarget(HomeAPIs.savePost(id: id))
         )
         .filterSuccessfulStatusCodes()
@@ -65,7 +140,7 @@ class HomeNetworkManager {
     
     // 게시글 저장 취소
     func cancelSavePost(id: Int) -> Single<Void> {
-        return provider.rx.request(
+        return authProvider.rx.request(
             MultiTarget(HomeAPIs.cancelSavePost(id: id))
         )
         .filterSuccessfulStatusCodes()
@@ -74,7 +149,7 @@ class HomeNetworkManager {
     
     // 게시글 신고
     func reportPost(id: Int) -> Single<Void> {
-        return provider.rx.request(
+        return authProvider.rx.request(
             MultiTarget(HomeAPIs.reportPost(id: id))
         )
         .filterSuccessfulStatusCodes()
@@ -83,7 +158,7 @@ class HomeNetworkManager {
     
     // 게시글 삭제
     func deletePost(id: Int) -> Single<Void> {
-        return provider.rx.request(
+        return authProvider.rx.request(
             MultiTarget(HomeAPIs.deletePost(id: id))
         )
         .filterSuccessfulStatusCodes()
@@ -92,7 +167,7 @@ class HomeNetworkManager {
     
     // 댓글 생성
     func createPostComment(postId: Int, content: String) -> Single<Void> {
-        return provider.rx.request(
+        return authProvider.rx.request(
             MultiTarget(HomeAPIs.createPostComment(postId: postId, content: content))
         )
         .filterSuccessfulStatusCodes()
@@ -101,7 +176,7 @@ class HomeNetworkManager {
     
     // 댓글 수정
     func patchPostComment(id: Int, content: String) -> Single<Void> {
-        return provider.rx.request(
+        return authProvider.rx.request(
             MultiTarget(HomeAPIs.patchPostComment(id: id, content: content))
         )
         .filterSuccessfulStatusCodes()
@@ -110,7 +185,7 @@ class HomeNetworkManager {
     
     // 댓글 삭제
     func deletePostComment(id: Int) -> Single<Void> {
-        return provider.rx.request(
+        return authProvider.rx.request(
             MultiTarget(HomeAPIs.deletePostComment(id: id))
         )
         .filterSuccessfulStatusCodes()
@@ -119,7 +194,7 @@ class HomeNetworkManager {
     
     // 댓글 신고
     func reportPostComment(id: Int) -> Single<Void> {
-        return provider.rx.request(
+        return authProvider.rx.request(
             MultiTarget(HomeAPIs.reportPostComment(id: id))
         )
         .filterSuccessfulStatusCodes()


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
closed: #111

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- NetworkManager의 홈 파트를 HomeNetworkManager로 분리했습니다.
- AuthorizedAPI와 PublicAPI의 홈 파트를 HomeAPIs로 분리했습니다.
- AuthorizedModel과 PublicModel의 홈 파트를 HomeAPIModels로 분리했습니다.

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 로직 수정은 거의 없어 코드 컨벤션 위주로 보시면 될 것 같습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 기존 NetworkManager는 싱글톤 패턴이 필요 없을 듯합니다. 주석에 설명하였습니다.
- 나머지 파트도 분리작업 후 Common의 NetworkManager 산하 파일과 클래스의 이름을 Common- 으로 시작하는 것이 좋을 것 같습니다.
  - 예) CommonNetworkManager, CommonAPIs, CommonAPIModels...

## ✅ Checklist
<!-- 아래 내용은 확인 해주세요. -->
- [x] 주석 및 프린트문 제거 확인
- [x] 컨벤션 준수 확인
