### PR TITLE
[Fix] AutoHeightTextView 높이 제약 오류 수정

### DIFF
--- a/SoBunSoBun/Common/Components/AutoHeightTextView.swift
+++ b/SoBunSoBun/Common/Components/AutoHeightTextView.swift
@@ -98,7 +98,7 @@ class AutoHeightTextView: UIView {
         textView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
             // 초기 높이 설정
-            heightConstraint = make.height.greaterThanOrEqualTo(minHeight).constraint
+            heightConstraint = make.height.greaterThanOrEqualTo(minHeight).priority(.high).constraint
         }
         
         addSubview(charactersLabel)


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
closed: #121

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- AutoHeightTextView 높이 constaint의 오류를 수정했습니다.
  - priority를 high로 설정하였습니다.

## ✅ Checklist
<!-- 아래 내용은 확인 해주세요. -->
- [x] 주석 및 프린트문 제거 확인
- [x] 컨벤션 준수 확인
