### PR TITLE
[Refactor] 알림 수신 설정 로직 개선

### DIFF
--- a/SoBunHaeYo/Views/Settings/NotificationSetting/NotificationSettingView.swift
+++ b/SoBunHaeYo/Views/Settings/NotificationSetting/NotificationSettingView.swift
@@ -131,7 +131,7 @@ extension NotificationSettingView {
         
         alert.onPrimaryTapped = {
             // 설정 앱으로 이동
-            if let settingsUrl = URL(string: UIApplication.openSettingsURLString) {
+            if let settingsUrl = URL(string: UIApplication.openNotificationSettingsURLString) {
                 UIApplication.shared.open(settingsUrl)
             }
         }


### PR DESCRIPTION
알림 설정 부분까지 이동하는 코드로 수정

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
closed: #235 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 알림 수신 설정 화면에서 설정 화면으로 이동시 기존 앱 설정 화면으로 이동에서 소분해요 앱의 알림 설정 화면으로 직접 이동

## 📌 참고 이미지
<table align="center">
  <tr>
    <td align="center" width="50%"><b>변경 전</b></td>
    <td align="center" width="50%"><b>변경 후</b></td>
  </tr>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/98f314ad-690d-4856-9734-f2e974099839" width="90%">
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/58fc1031-fc03-44da-b23a-73d69d42f0f1" width="90%">
    </td>
  </tr>
</table>
 

## ✅ Checklist
<!-- 아래 내용은 확인 해주세요. -->
- [x] 주석 및 프린트문 제거 확인
- [x] 컨벤션 준수 확인
