### PR TITLE
[Build] 빌드 버전 수정

### DIFF
--- a/SoBunHaeYo.xcodeproj/project.pbxproj
+++ b/SoBunHaeYo.xcodeproj/project.pbxproj
@@ -332,7 +332,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 26.0.2;
+				MARKETING_VERSION = 26.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.seongpil.SoBunHaeYo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -368,7 +368,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 26.0.2;
+				MARKETING_VERSION = 26.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.seongpil.SoBunHaeYo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -527,7 +527,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 26.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.seongpil.SoBunHaeYo.NotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -560,7 +560,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 26.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.seongpil.SoBunHaeYo.NotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
NotificationService와 SoBunHaeYo의 Marketing Version을 26.0.3으로 수정

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
closed: #259 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- NotificationService Version을 1.0에서 26.0.3로 업데이트 버전에 맞게 수정
- SoBunHaeYo Version을 26.0.2에서 26.0.3로 업데이트 버전에 맞게 수정

## ✅ Checklist
<!-- 아래 내용은 확인 해주세요. -->
- [x] 주석 및 프린트문 제거 확인
- [x] 컨벤션 준수 확인
